### PR TITLE
[add] 이메일 인증 기능 추가**

### DIFF
--- a/document/db/script/DDL.sql
+++ b/document/db/script/DDL.sql
@@ -30,6 +30,10 @@ DROP TABLE bookmark
 DROP TABLE contact_history 
 	CASCADE CONSTRAINTS;
 
+/* email 인증 */
+DROP TABLE email_auth
+	CASCADE CONSTRAINTS;
+
 /* 회원 */
 CREATE TABLE member (
 	member_id NUMBER NOT NULL, /* 회원번호 */
@@ -102,6 +106,12 @@ CREATE TABLE contact_history (
 	bid_time DATE /* 입찰시간 */
 );
 
+/* email 인증 */
+CREATE TABLE email_auth (
+	email VARCHAR2(30) PRIMARY KEY, /* 이메일 */
+	auth_key VARCHAR2(30) NOT NULL, /* 인증키*/
+	auth_status NUMBER(1) DEFAULT 0 NOT NULL /* 상태 : 1이면 인증 완료*/
+);
 
 commit;
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,13 +155,27 @@
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
-<dependency>
-    <groupId>org.projectlombok</groupId>
-    <artifactId>lombok</artifactId>
-    <version>1.18.12</version>
-    <scope>provided</scope>
-</dependency>
+		<dependency>
+		    <groupId>org.projectlombok</groupId>
+		    <artifactId>lombok</artifactId>
+		    <version>1.18.12</version>
+		    <scope>provided</scope>
+		</dependency>
 		
+		<!-- 메일 인증 관련 라이브러리 -->
+		<!-- 이메일 인증: https://mvnrepository.com/artifact/javax.mail/mail -->
+		<dependency>
+			<groupId>javax.mail</groupId>
+			<artifactId>mail</artifactId>
+			<version>1.4.7</version>
+		</dependency>
+		
+		<!-- https://mvnrepository.com/artifact/org.springframework/spring-context-support -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+			<version>5.2.0.RELEASE</version>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/com/kk/controller/EmailAuthController.java
+++ b/src/main/java/com/kk/controller/EmailAuthController.java
@@ -1,0 +1,88 @@
+package com.kk.controller;
+
+import java.util.HashMap;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kk.domain.EmailAuthVO;
+import com.kk.service.MailSendService;
+
+@Controller
+public class EmailAuthController {
+	
+    @Autowired
+    private MailSendService mss;
+
+    @RequestMapping("main/emailAuth/sendingEmail.do")
+     public void btnClick(@ModelAttribute EmailAuthVO vo){
+    	
+    	System.out.println("EmailAuthController : 메일인증 시작");
+    	
+        //// 일단 이메일 보내기
+    	// 이메일 인증키 생성 및 전송
+        String authKey = mss.sendAuthMail(vo.getEmail());
+        
+        //// DB 저장 과정
+        // 설정한 인증키 vo에 반영
+        vo.setAuthKey(authKey);
+        
+        // DB에 해당 메일 존재 여부 확인
+    	if(mss.getEmail(vo)==null) {
+    		// 존재하지 않는 경우 insert // DB에 기본정보 insert
+    		System.out.println("EmailAuthController : 메일인증 테이블에 내 데이터 주입");
+    		vo.setAuthStatus(0);
+    		mss.insert(vo);
+    	} else {
+    		// 존재시 업데이트 - state는 0으로 셋팅해주기
+    		System.out.println("EmailAuthController : 메일인증 테이블 내 데이터 업데이트");
+    		vo.setAuthStatus(0);
+    		mss.update(vo);
+    	}
+  	}
+    
+    // 이메일 링크 클릭시    
+    @RequestMapping(value="main/signUpConfirm", produces="application/text; charset=utf8")
+    public String confirm(@ModelAttribute EmailAuthVO vo){
+    	
+        // 요청받은 것을 DB에서 확인
+    	EmailAuthVO dbVO = mss.getEmail(vo);
+    	// 일치시 getStatus 변경하여 업데이트
+    	if(dbVO.getAuthKey().equals(vo.getAuthKey())) {
+    		vo.setAuthStatus(1);
+    		mss.update(vo);
+    		System.out.println("EmailAuthController : 메일인증 성공 페이지로 이동");
+    		return "redirect:authSuccess.do";
+    	}
+    	System.out.println("EmailAuthController : 메일인증 실패 페이지로 이동");
+    	return "redirect:authFail.do";
+ 	}
+    
+    // 인증페이지 연결
+    @RequestMapping(value= {"main/authSuccess.do", "main/authFail.do"}, produces="application/text; charset=utf8")
+    public void authPage(){
+ 	}
+    
+    // 회원가입 버튼 활성화시 ajax 통신으로 유효성 확인하기
+    @RequestMapping(value="main/emailAuth/signUp.do", produces="application/text; charset=utf8")
+    @ResponseBody
+    public String finalConfirm(@ModelAttribute EmailAuthVO vo){
+    	
+    	// default는 인증 미완료
+    	String data = "0";
+    	
+        // 요청받은 것을 DB에서 꺼내오기
+    	EmailAuthVO dbVO = mss.getEmail(vo);
+    	// getStatue가 1인 경우(이메일 인증 완료), data = 1로 변경
+    	if(dbVO.getAuthStatus() == 1) {
+    		data = "1";
+    	}
+    	
+    	return data;
+ 	}
+}

--- a/src/main/java/com/kk/controller/MemberController.java
+++ b/src/main/java/com/kk/controller/MemberController.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.kk.domain.MemberVO;
 import com.kk.service.MemberService;
@@ -32,4 +33,20 @@ public class MemberController {
 		
 		return result;
 	}
+	
+	// 회원가입 sumbit -> Member Insert를 위한 메소드
+	@RequestMapping(value="main/signUp.do", produces="application/text; charset=utf8")
+	public String insertMember(MemberVO vo) {
+		
+		// 한번 더 유효성 검사
+		if( vo.getEmail()!=null && vo.getName()!=null && vo.getPassword()!=null && vo.getTel()!=0 ) {
+			System.out.println("MemberController : insertMember - 가입 진행");
+			memberService.insertMember(vo);
+		}
+		
+		return "redirect:login.do";
+	}
+	
+	
 }
+

--- a/src/main/java/com/kk/dao/EmailAuthDAO.java
+++ b/src/main/java/com/kk/dao/EmailAuthDAO.java
@@ -1,0 +1,9 @@
+package com.kk.dao;
+
+import com.kk.domain.EmailAuthVO;
+
+public interface EmailAuthDAO {
+	EmailAuthVO getEmail(EmailAuthVO vo);
+	int insert(EmailAuthVO vo);
+	int update(EmailAuthVO vo);
+}

--- a/src/main/java/com/kk/dao/EmailAuthDAOImpl.java
+++ b/src/main/java/com/kk/dao/EmailAuthDAOImpl.java
@@ -1,0 +1,33 @@
+package com.kk.dao;
+
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kk.domain.EmailAuthVO;
+
+@Repository("EmailAuthDAO")
+public class EmailAuthDAOImpl implements EmailAuthDAO{
+
+	@Autowired
+	SqlSessionTemplate mybatis;
+	
+	@Override
+	public EmailAuthVO getEmail(EmailAuthVO vo) {
+		return mybatis.selectOne("emailAuth.getEmail", vo);
+	}
+
+	@Override
+	public int insert(EmailAuthVO vo) {
+		int result = mybatis.insert("emailAuth.insert", vo);
+		return result;
+	}
+
+	@Override
+	public int update(EmailAuthVO vo) {
+		int result = mybatis.update("emailAuth.update", vo);
+		return result;
+	}
+
+}

--- a/src/main/java/com/kk/dao/MemberDAO.java
+++ b/src/main/java/com/kk/dao/MemberDAO.java
@@ -1,10 +1,14 @@
 package com.kk.dao;
 
+import java.util.List;
+
 import com.kk.domain.MemberVO;
 
 // MemberDAOImpl에서 구현 예정
 public interface MemberDAO {
 
 	MemberVO getMember(MemberVO vo);
+	List<MemberVO> getMemberList(MemberVO vo);
+	int insertMember(MemberVO vo);
 	
 }

--- a/src/main/java/com/kk/dao/MemberDAOImpl.java
+++ b/src/main/java/com/kk/dao/MemberDAOImpl.java
@@ -1,5 +1,7 @@
 package com.kk.dao;
 
+import java.util.List;
+
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -15,6 +17,19 @@ public class MemberDAOImpl implements MemberDAO {
 	@Override
 	public MemberVO getMember(MemberVO vo) {
 		return mybatis.selectOne("member.getMember", vo);
+	}
+
+	@Override
+	public List<MemberVO> getMemberList(MemberVO vo) {
+		return mybatis.selectList("member.getMemberList", vo);
+	}
+
+	@Override
+	public int insertMember(MemberVO vo) {
+		int result = mybatis.insert("member.insertMember", vo);
+		System.out.println(vo);
+		System.out.println("MemberDAO: " + result);
+		return result;
 	}
 
 }

--- a/src/main/java/com/kk/domain/EmailAuthVO.java
+++ b/src/main/java/com/kk/domain/EmailAuthVO.java
@@ -1,0 +1,50 @@
+package com.kk.domain;
+
+// 회원 DTO
+public class EmailAuthVO {
+	
+	private String email; // 이메일
+	private String authKey; // 인증크
+	private int authStatus; // 상태
+	
+	public EmailAuthVO() {
+
+	}
+	
+	public EmailAuthVO(String email, String authKey, int authStatus) {
+		super();
+		this.email = email;
+		this.authKey = authKey;
+		this.authStatus = authStatus;
+	}
+	
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public String getAuthKey() {
+		return authKey;
+	}
+
+	public void setAuthKey(String authKey) {
+		this.authKey = authKey;
+	}
+
+	public int getAuthStatus() {
+		return authStatus;
+	}
+
+	public void setAuthStatus(int authStatus) {
+		this.authStatus = authStatus;
+	}
+
+	@Override
+	public String toString() {
+		return "EmailAuthVO [email=" + email + ", authKey=" + authKey + ", authState=" + authStatus + "]";
+	}
+	
+}

--- a/src/main/java/com/kk/service/MailSendService.java
+++ b/src/main/java/com/kk/service/MailSendService.java
@@ -1,0 +1,90 @@
+package com.kk.service;
+
+import java.util.Random;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.stereotype.Service;
+
+import com.kk.dao.EmailAuthDAO;
+import com.kk.domain.EmailAuthVO;
+
+@Service("mss")
+public class MailSendService {
+    
+    @Autowired
+    private EmailAuthDAO emailAuthDAO;
+    
+    // DB에 이메일이 있는지 확인하는 메소드
+    public EmailAuthVO getEmail(EmailAuthVO vo) {
+    	return emailAuthDAO.getEmail(vo);
+    }
+    
+    // DB에 넣기
+    public int insert(EmailAuthVO vo) {
+    	return emailAuthDAO.insert(vo);
+    }
+    
+    // DB 업데이트 하기
+    public int update(EmailAuthVO vo) {
+    	return emailAuthDAO.update(vo);
+    }
+
+    
+    /////////////// 이하 비즈니스 로직  - 키 생성 및 메일 전송
+    
+    @Autowired
+    private JavaMailSenderImpl mailSender;
+    
+    int size;
+    
+    //인증키 생성
+    private String getKey(int size) {
+        this.size = size;
+        return getAuthCode();
+    }
+
+    //인증코드 난수 발생
+    private String getAuthCode() {
+        Random random = new Random();
+        StringBuffer buffer = new StringBuffer();
+        int num = 0;
+
+        while(buffer.length() < size) {
+            num = random.nextInt(10);
+            buffer.append(num);
+        }
+
+        return buffer.toString();
+    }
+
+    //인증메일 보내기
+    public String sendAuthMail(String email) {
+    	
+    	String authKey = getKey(12);
+    	
+    	MimeMessage mail = mailSender.createMimeMessage();
+        String mailContent = "<h1>[이메일 인증]</h1><br><p>아래 링크를 클릭하시면 이메일 인증이 완료됩니다.</p>"
+                            + "<a href='http://localhost:8180/kkini_kkili/main/signUpConfirm?email=" 
+                            + email + "&authKey=" + authKey + "' target='_blenk'>이메일 인증 확인</a>";
+
+        try {
+            mail.setSubject("회원가입 이메일 인증 ", "utf-8");
+            mail.setText(mailContent, "utf-8", "html");
+            mail.addRecipient(Message.RecipientType.TO, new InternetAddress(email));
+            mailSender.send(mail);
+        } catch (MessagingException e) {
+            e.printStackTrace();
+        }
+        
+        return authKey;
+    }
+    
+    
+    
+}

--- a/src/main/java/com/kk/service/MemberService.java
+++ b/src/main/java/com/kk/service/MemberService.java
@@ -10,5 +10,6 @@ import com.kk.domain.MemberVO;
 public interface MemberService {
 	MemberVO getMember(MemberVO vo);
 	List<MemberVO> getMemberList(MemberVO vo);
+	int insertMember(MemberVO vo);
 	
 }

--- a/src/main/java/com/kk/service/MemberServiceImpl.java
+++ b/src/main/java/com/kk/service/MemberServiceImpl.java
@@ -21,8 +21,12 @@ public class MemberServiceImpl implements MemberService{
 
 	@Override
 	public List<MemberVO> getMemberList(MemberVO vo) {
-		// TODO Auto-generated method stub
-		return null;
+		return memberDAO.getMemberList(vo);
+	}
+
+	@Override
+	public int insertMember(MemberVO vo) {
+		return memberDAO.insertMember(vo);
 	}
 	
 }

--- a/src/main/java/mappers/EmailAuthMapper.xml
+++ b/src/main/java/mappers/EmailAuthMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="emailAuth">
+
+	<!-- 이메일 인증 관련 매퍼 -->
+	<select id="getEmail" parameterType="emailAuth" resultType="emailAuth">
+		SELECT * FROM EMAIL_AUTH WHERE email = #{email}
+	</select>
+	
+	<insert id="insert" parameterType="emailAuth">
+		INSERT INTO EMAIL_AUTH(email, auth_key, auth_status) VALUES(#{email}, #{authKey}, #{authStatus})
+	</insert>
+
+	<update id="update" parameterType="emailAuth">
+		UPDATE EMAIL_AUTH SET auth_key = #{authKey}, auth_status = #{authStatus} WHERE email = #{email}
+	</update>
+
+</mapper>

--- a/src/main/java/mappers/MemberMapper.xml
+++ b/src/main/java/mappers/MemberMapper.xml
@@ -12,7 +12,16 @@
 		 WHERE email = #{email}
 	</select>
 	
+	<select id="getMemberList" resultType="member">
+		SELECT *
+		FROM member
+	</select>
+	
 	<!-- 가입 -->
+	<insert id="insertMember">
+		INSERT INTO member(member_id, name, email, password, tel, auth, join_date, last_conn_date)
+		VALUES(seq_mid.nextval, #{name}, #{email}, #{password}, ${tel}, 0, SYSDATE, SYSDATE)
+	</insert>
 	
 	<!-- 개인정보 수정 -->
 	

--- a/src/main/java/mybatis-config.xml
+++ b/src/main/java/mybatis-config.xml
@@ -14,6 +14,7 @@
 		<typeAlias alias="member" type="com.kk.domain.MemberVO" />
 		<typeAlias alias="cmt" type="com.kk.domain.CmtVO" />
 		<typeAlias alias="contact" type="com.kk.domain.ContactVO" />
+		<typeAlias alias="emailAuth" type="com.kk.domain.EmailAuthVO" />
 	</typeAliases>
 
 

--- a/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -31,6 +31,22 @@
 		<constructor-arg name="sqlSessionFactory"
 			ref="sqlSessionFactory"></constructor-arg>
 	</bean>
+	
+	<!-- email confirm -->
+	<bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
+		<property name="host" value="smtp.gmail.com"></property>
+		<property name="port" value="587"></property>
+		<property name="username" value="kkinikkili@gmail.com"></property>
+		<property name="password" value="KKkkKKkk!"></property>
+		<property name="JavaMailProperties">
+			<props>
+                <prop key="mail.transport.protocol">smtp</prop>
+                <prop key="mail.smtp.auth">true</prop>
+                <prop key="mail.smtp.starttls.enable">true</prop>
+                <prop key="mail.debug">true</prop>
+            </props>
+        </property>
+	</bean>
 </beans>
 
 

--- a/src/main/webapp/WEB-INF/views/main/authFail.jsp
+++ b/src/main/webapp/WEB-INF/views/main/authFail.jsp
@@ -1,0 +1,12 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>끼니끼리 : 인증 실패 페이지</title>
+</head>
+<body>
+	<h1>인증에 실패하였습니다.</h1>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/main/authSuccess.jsp
+++ b/src/main/webapp/WEB-INF/views/main/authSuccess.jsp
@@ -1,0 +1,12 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>끼니끼리 : 인증 성공 페이지</title>
+</head>
+<body>
+	<h1>인증에 성공하였습니다.</h1>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/main/sign.jsp
+++ b/src/main/webapp/WEB-INF/views/main/sign.jsp
@@ -106,7 +106,7 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col-sm-12">
-                    <form id="registerForm" class="md-float-material form-material">
+                    <form id="registerForm" class="md-float-material form-material" action="signUp.do" method="post">
                         <!-- <div class="text-center">
                             <img src="assets/images/logo.png" alt="logo.png">
                         </div> -->
@@ -142,12 +142,11 @@
                                 <div class="row">
                                     <div class="col-md-12">
                                         <span><button id="confirm" type="button" class="btn btn-primary btn-md btn-blocktext-center m-b-20">이메일 인증</button></span>
-                                        <input type="text" class="form-control col-md-8 f-right" placeholder="인증키 입력">
+                                        <!-- <input type="text" class="form-control col-md-8 f-right"> -->
+                                        <div class="col-md-8 f-right"></div>
                                     </div>
                                 </div>
                                 
-                                
-
                                 <div class="form-group form-primary">
                                     <input type="tel" id="tel" name="tel" maxlength="11" class="form-control digits" id="tel" required>
                                     <span class="form-bar"></span>

--- a/src/main/webapp/resources/js/signValidate.js
+++ b/src/main/webapp/resources/js/signValidate.js
@@ -10,6 +10,10 @@ checkbox : 이용약관 체크
 
 */
 
+/*테스트용
+ * email = true; email_check=true; email_confirm = true; password = true; cpassword = true; checkbox = true;
+ */
+
 // 아이디 중복 여부 확인
 	let email = false;
 	let email_check = false;
@@ -145,16 +149,82 @@ $(()=>{
         }
 	}); 
 	
+	// 이메일 인증키 관련 사항
+	$('#confirm').click(function(){
+		console.log("이메일 인증키 발송")
+		if(email_check==true){
+			// ajax 통신
+			$.ajax({
+	         	type :'post',
+	         	data : { "email" : $('#email').val()},               	
+	         	url : 'emailAuth/sendingEmail.do',
+	         	contentType : "application/x-www-form-urlencoded; charset=UTF-8",
+	         	
+			}); // end of ajax    
+		}
+		
+		alert("인증 메일 전송 완료 : 사용하는 메일에 따라 최대 5분 정도의 시간이 걸릴 수 있습니다. 스팸메일함도 확인해주세요.")
+	})
+	
+	// 제출 버튼을 tab으로 옮겨서 들어오는 경우
+	$('#submit_btn').focus(function(){
+		// 이메일 인증 여부 최종 확인
+		ajax_email_check();
+	})
+	
+	// 제출 버튼에 마우스 올라갈 때
+	$('#submit_btn').hover(function(){
+		// 이메일 인증 여부 최종 확인
+		ajax_email_check();
+	})
+	
+	// 회원가입 버튼 클릭시 submit 발동 조건
 	$('#submit_btn').click(function(){
+		
+		if(email_confirm == false){
+			alert("이메일 인증이 아직 완료되지 않았습니다");
+			return;
+		}
+		
+		// 최종 검사
 		console.log(email == true, email_check == true, email_confirm == true, 
 			password == true, cpassword == true, checkbox == true);
+		
+		// 제출
 		if(email == true && email_check == true && email_confirm == true && 
 			password == true && cpassword == true && checkbox == true){
 			$('#registerForm').submit(); 			
 		}
+		
 	})
-	
+
 })
+
+function ajax_email_check(){
+	// 이메일 인증 여부 최종 확인
+	if(email_check==true && email_confirm==false){
+		// ajax 통신
+		$.ajax({
+         	type :'post',
+         	data : { "email" : $('#email').val()},               	
+         	url : 'emailAuth/signUp.do',
+         	contentType : "application/x-www-form-urlencoded; charset=UTF-8",
+         	success : email_auth_suc
+//        	,error : function(err){
+//        		alert('error');
+//        		console.log(err);
+//        	}
+		}); // end of ajax    
+	}
+}
+
+function email_auth_suc(data) {
+	if(data == "1"){
+		email_confirm = true;
+	} else {
+		email_confirm = false;
+	}
+}
 	
 function suc(data){
 	if(data == "1"){


### PR DESCRIPTION
### **매우 중요**

- 이메일 인증 관련 테이블 생성 (email_auth : email, auth_key, auth_status)
- 이메일을 활용하기 위한 라이브러리 추가하였음
- 이메일 인증 관련 컨트롤러, 서비스, DAO, VO, Mapper 추가
- 이메일 인증 후 회원가입 버튼 클릭시 회원 테이블에 반영하는 부분 추가

- 인증 페이지(실패, 성공) 추가, 나중에 css 보완 필요